### PR TITLE
XSD voor DK GB PUSH principe is onjuist

### DIFF
--- a/ch05_Grote berichten bijlagen.md
+++ b/ch05_Grote berichten bijlagen.md
@@ -241,8 +241,9 @@ Dit hoofdstuk presenteert een voorbeeld van de metadata van een bestand bij gebr
     <xs:attribute name="contextId" use="optional" />
   </xs:complexType>
   <xs:complexType name="location">
+    <xs:choice>
        <xs:element name="receiverUrl" type="tns:urlType" />
-    
+    </xs:choice>
   </xs:complexType>
   <xs:simpleType name="gb-profile" final="restriction">
     <xs:restriction base="xs:string">


### PR DESCRIPTION
Een element mag niet direct onder complexType worden opgenomen. De choice moet daarom blijven, al is er maar één keuze over door het niet toestaan van senderUrl.